### PR TITLE
Change timeout functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "doctrine/orm": "^2.7",
         "doctrine/persistence": "^1.3 || ^2.0",
         "eventsauce/backoff": "^1.1",
-        "happyr/doctrine-specification": "^2.0",
         "setono/doctrine-object-manager-trait": "^1.0",
         "stof/doctrine-extensions-bundle": "^1.6",
         "symfony/config": "^4.4 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "doctrine/orm": "^2.7",
         "doctrine/persistence": "^1.3 || ^2.0",
         "eventsauce/backoff": "^1.1",
+        "happyr/doctrine-specification": "^2.0",
         "setono/doctrine-object-manager-trait": "^1.0",
         "stof/doctrine-extensions-bundle": "^1.6",
         "symfony/config": "^4.4 || ^5.0",

--- a/src/Command/TimeoutJobsCommand.php
+++ b/src/Command/TimeoutJobsCommand.php
@@ -4,40 +4,72 @@ declare(strict_types=1);
 
 namespace Setono\JobStatusBundle\Command;
 
-use Happyr\DoctrineSpecification\Spec;
+use Doctrine\Persistence\ManagerRegistry;
+use Setono\DoctrineObjectManagerTrait\ORM\ORMManagerTrait;
 use Setono\JobStatusBundle\Entity\JobInterface;
 use Setono\JobStatusBundle\Repository\JobRepositoryInterface;
+use Setono\JobStatusBundle\Workflow\JobWorkflow;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Workflow\Registry;
+use Symfony\Component\Workflow\WorkflowInterface;
 
 final class TimeoutJobsCommand extends Command
 {
+    use ORMManagerTrait;
+
     protected static $defaultName = 'setono:job-status:timeout';
+
+    /** @var string|null */
+    protected static $defaultDescription = "Clean up timed out jobs by moving them to the 'timed_out' state";
 
     private JobRepositoryInterface $jobRepository;
 
-    public function __construct(JobRepositoryInterface $jobRepository)
-    {
+    private Registry $workflowRegistry;
+
+    public function __construct(
+        JobRepositoryInterface $jobRepository,
+        Registry $workflowRegistry,
+        ManagerRegistry $managerRegistry
+    ) {
         parent::__construct();
 
         $this->jobRepository = $jobRepository;
+        $this->workflowRegistry = $workflowRegistry;
+        $this->managerRegistry = $managerRegistry;
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription((string) self::$defaultDescription);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        /**
-        ->andWhere('DATE_ADD(o.updatedAt, INTERVAL o.waitForTimeout SECOND) < :now')
-        ->setParameter('now', new \DateTime())
-         */
         do {
-            $spec = Spec::andX(
-                Spec::lt(Spec::DATE_ADD()),
-                Spec::eq('state', JobInterface::STATE_RUNNING)
-            );
-            $jobs = $this->jobRepository->match();
+            $jobs = $this->jobRepository->findPassedTimeout();
+
+            $manager = null;
+
+            foreach ($jobs as $job) {
+                $workflow = $this->getWorkflow($job);
+                $workflow->apply($job, JobWorkflow::TRANSITION_TIMEOUT);
+
+                $manager = $this->getManager($job);
+                $manager->flush();
+            }
+
+            if (null !== $manager) {
+                $manager->clear();
+            }
         } while (count($jobs) > 0);
 
         return 0;
+    }
+
+    private function getWorkflow(JobInterface $job): WorkflowInterface
+    {
+        return $this->workflowRegistry->get($job, JobWorkflow::NAME);
     }
 }

--- a/src/Command/TimeoutJobsCommand.php
+++ b/src/Command/TimeoutJobsCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\JobStatusBundle\Command;
+
+use Happyr\DoctrineSpecification\Spec;
+use Setono\JobStatusBundle\Entity\JobInterface;
+use Setono\JobStatusBundle\Repository\JobRepositoryInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class TimeoutJobsCommand extends Command
+{
+    protected static $defaultName = 'setono:job-status:timeout';
+
+    private JobRepositoryInterface $jobRepository;
+
+    public function __construct(JobRepositoryInterface $jobRepository)
+    {
+        parent::__construct();
+
+        $this->jobRepository = $jobRepository;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /**
+        ->andWhere('DATE_ADD(o.updatedAt, INTERVAL o.waitForTimeout SECOND) < :now')
+        ->setParameter('now', new \DateTime())
+         */
+        do {
+            $spec = Spec::andX(
+                Spec::lt(Spec::DATE_ADD()),
+                Spec::eq('state', JobInterface::STATE_RUNNING)
+            );
+            $jobs = $this->jobRepository->match();
+        } while (count($jobs) > 0);
+
+        return 0;
+    }
+}

--- a/src/Entity/Job.php
+++ b/src/Entity/Job.php
@@ -25,8 +25,6 @@ class Job implements JobInterface
 
     protected string $state = self::STATE_PENDING;
 
-    protected ?int $waitForTimeout = null;
-
     protected DateTimeInterface $createdAt;
 
     protected DateTimeInterface $updatedAt;
@@ -36,6 +34,10 @@ class Job implements JobInterface
     protected ?DateTimeInterface $failedAt = null;
 
     protected ?DateTimeInterface $finishedAt = null;
+
+    protected ?DateTimeInterface $timesOutAt = null;
+
+    protected int $ttl = 0;
 
     protected int $step = 0;
 
@@ -137,16 +139,6 @@ class Job implements JobInterface
         return $this->state === self::STATE_FINISHED;
     }
 
-    public function getWaitForTimeout(): ?int
-    {
-        return $this->waitForTimeout;
-    }
-
-    public function setWaitForTimeout(?int $waitForTimeout): void
-    {
-        $this->waitForTimeout = $waitForTimeout;
-    }
-
     public function getCreatedAt(): DateTimeInterface
     {
         return $this->createdAt;
@@ -165,6 +157,14 @@ class Job implements JobInterface
     public function setUpdatedAt(DateTimeInterface $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
+
+        if ($this->ttl > 0) {
+            try {
+                $this->timesOutAt = new \DateTimeImmutable(sprintf('+%d seconds', $this->ttl));
+            } catch (\Throwable $e) {
+                $this->timesOutAt = null;
+            }
+        }
     }
 
     public function getStartedAt(): ?DateTimeInterface
@@ -195,6 +195,28 @@ class Job implements JobInterface
     public function setFinishedAt(?DateTimeInterface $finishedAt): void
     {
         $this->finishedAt = $finishedAt;
+    }
+
+    public function getTimesOutAt(): ?DateTimeInterface
+    {
+        return $this->timesOutAt;
+    }
+
+    public function setTimesOutAt(?DateTimeInterface $timesOutAt): void
+    {
+        $this->timesOutAt = $timesOutAt;
+    }
+
+    public function getTtl(): int
+    {
+        return $this->ttl;
+    }
+
+    public function setTtl(int $ttl): void
+    {
+        Assert::greaterThanEq($ttl, 0);
+
+        $this->ttl = $ttl;
     }
 
     public function getStep(): int

--- a/src/Entity/JobInterface.php
+++ b/src/Entity/JobInterface.php
@@ -66,14 +66,6 @@ interface JobInterface
 
     public function isFinished(): bool;
 
-    /**
-     * The number of seconds a job can be running without being declared 'timed out'
-     * Null means to wait forever
-     */
-    public function getWaitForTimeout(): ?int;
-
-    public function setWaitForTimeout(int $waitForTimeout): void;
-
     public function getCreatedAt(): DateTimeInterface;
 
     public function setCreatedAt(DateTimeInterface $createdAt): void;
@@ -96,6 +88,21 @@ interface JobInterface
     public function getFinishedAt(): ?DateTimeInterface;
 
     public function setFinishedAt(?DateTimeInterface $finishedAt): void;
+
+    /**
+     * The time when this job times out and should be moved to 'timed_out' state
+     */
+    public function getTimesOutAt(): ?DateTimeInterface;
+
+    public function setTimesOutAt(?DateTimeInterface $timesOutAt): void;
+
+    /**
+     * The number of seconds a job can be running without being declared 'timed out'
+     * 0 means to wait forever
+     */
+    public function getTtl(): int;
+
+    public function setTtl(int $ttl): void;
 
     /**
      * The current step, i.e. 45 out of 125, 45 is the step

--- a/src/Factory/JobFactory.php
+++ b/src/Factory/JobFactory.php
@@ -9,17 +9,17 @@ use Setono\JobStatusBundle\Entity\JobInterface;
 
 final class JobFactory implements JobFactoryInterface
 {
-    private int $defaultWaitForTimeout;
+    private int $defaultTtl;
 
-    public function __construct(int $defaultWaitForTimeout)
+    public function __construct(int $defaultTtl)
     {
-        $this->defaultWaitForTimeout = $defaultWaitForTimeout;
+        $this->defaultTtl = $defaultTtl;
     }
 
     public function createNew(): JobInterface
     {
         $job = new Job();
-        $job->setWaitForTimeout($this->defaultWaitForTimeout);
+        $job->setTtl($this->defaultTtl);
 
         $pid = getmypid();
         if (false !== $pid) {

--- a/src/Repository/JobRepository.php
+++ b/src/Repository/JobRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Setono\JobStatusBundle\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Happyr\DoctrineSpecification\Repository\EntitySpecificationRepositoryTrait;
 use Setono\JobStatusBundle\Entity\JobInterface;
 
 /**
@@ -12,6 +13,8 @@ use Setono\JobStatusBundle\Entity\JobInterface;
  */
 class JobRepository extends ServiceEntityRepository implements JobRepositoryInterface
 {
+    use EntitySpecificationRepositoryTrait;
+
     public function findRunning(array $orderBy = ['updatedAt' => 'DESC'], int $limit = 1000, int $offset = null): array
     {
         return $this->findBy(['state' => JobInterface::STATE_RUNNING], $orderBy, $limit, $offset);

--- a/src/Repository/JobRepositoryInterface.php
+++ b/src/Repository/JobRepositoryInterface.php
@@ -5,10 +5,9 @@ declare(strict_types=1);
 namespace Setono\JobStatusBundle\Repository;
 
 use Doctrine\Persistence\ObjectRepository;
-use Happyr\DoctrineSpecification\Repository\EntitySpecificationRepositoryInterface;
 use Setono\JobStatusBundle\Entity\JobInterface;
 
-interface JobRepositoryInterface extends ObjectRepository, EntitySpecificationRepositoryInterface
+interface JobRepositoryInterface extends ObjectRepository
 {
     /**
      * @param array<string, string> $orderBy
@@ -29,13 +28,12 @@ interface JobRepositoryInterface extends ObjectRepository, EntitySpecificationRe
     public function findByType(string $type, array $orderBy = null, int $limit = 1000, int $offset = null): array;
 
     /**
-     * Returns a list of Jobs that are candidates for issuing a timeout transition, i.e. jobs
-     * that has been inactive for a period longer than the 'wait for timeout' property
+     * Returns a list of Jobs where the timesOutAt timestamp has passed and are still running
      *
      * @param array<string, string>|null $orderBy
      * @psalm-return list<JobInterface>
      */
-    public function findCandidatesForTimeout(array $orderBy = null, int $limit = 1000, int $offset = null): array;
+    public function findPassedTimeout(array $orderBy = null, int $limit = 1000, int $offset = null): array;
 
     /**
      * Returns true if an exclusive job of the given type is running

--- a/src/Repository/JobRepositoryInterface.php
+++ b/src/Repository/JobRepositoryInterface.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Setono\JobStatusBundle\Repository;
 
 use Doctrine\Persistence\ObjectRepository;
+use Happyr\DoctrineSpecification\Repository\EntitySpecificationRepositoryInterface;
 use Setono\JobStatusBundle\Entity\JobInterface;
 
-interface JobRepositoryInterface extends ObjectRepository
+interface JobRepositoryInterface extends ObjectRepository, EntitySpecificationRepositoryInterface
 {
     /**
      * @param array<string, string> $orderBy

--- a/src/Resources/config/services/factory.xml
+++ b/src/Resources/config/services/factory.xml
@@ -3,12 +3,12 @@
 <container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
-        <!-- The default wait for a timeout is 6 hours -->
-        <parameter key="setono_job_status_default_wait_for_timeout">21600</parameter>
+        <!-- The default ttl is 6 hours -->
+        <parameter key="setono_job_status.default_ttl">21600</parameter>
     </parameters>
     <services>
         <service id="setono_job_status.factory.job" class="Setono\JobStatusBundle\Factory\JobFactory">
-            <argument>%setono_job_status_default_wait_for_timeout%</argument>
+            <argument>%setono_job_status.default_ttl%</argument>
         </service>
     </services>
 </container>


### PR DESCRIPTION
This simplifies the timeout functionality because we update the `timesOutAt` timestamp each time the entity is updated. This makes it much simpler to query for timed out jobs.