### PR TITLE
Prune old jobs

### DIFF
--- a/src/Command/ListCommand.php
+++ b/src/Command/ListCommand.php
@@ -15,7 +15,6 @@ final class ListCommand extends Command
 {
     protected static $defaultName = 'setono:job-status:list';
 
-    /** @var string|null */
     protected static $defaultDescription = 'Lists the currently running jobs';
 
     private JobRepositoryInterface $jobRepository;

--- a/src/Command/PruneCommand.php
+++ b/src/Command/PruneCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\JobStatusBundle\Command;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Setono\DoctrineObjectManagerTrait\ORM\ORMManagerTrait;
+use Setono\JobStatusBundle\Repository\JobRepositoryInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+final class PruneCommand extends Command
+{
+    use ORMManagerTrait;
+
+    protected static $defaultName = 'setono:job-status:prune';
+
+    protected static $defaultDescription = 'Prunes the jobs in the database by removing old entries';
+
+    private JobRepositoryInterface $jobRepository;
+
+    private int $defaultHours;
+
+    public function __construct(JobRepositoryInterface $jobRepository, ManagerRegistry $managerRegistry, int $defaultHours)
+    {
+        parent::__construct();
+
+        $this->jobRepository = $jobRepository;
+        $this->managerRegistry = $managerRegistry;
+        $this->defaultHours = $defaultHours;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription((string) self::$defaultDescription)
+            ->addOption(
+                'hours',
+                'h',
+                InputOption::VALUE_REQUIRED,
+                'Set the number of hours a job has to be to be pruned/removed',
+                (string) $this->defaultHours
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        /** @var mixed $hours */
+        $hours = $input->getOption('hours');
+        Assert::integerish($hours);
+
+        $hours = (int) $hours;
+
+        $threshold = new \DateTimeImmutable(sprintf('-%d hours', $hours));
+        $io->text(sprintf('Removes jobs not updated since %s', $threshold->format('Y-m-d H:i')));
+
+        $jobs = $this->jobRepository->findNotUpdatedSince($threshold);
+
+        $manager = null;
+        $jobsRemoved = 0;
+        foreach ($jobs as $job) {
+            $jobsRemoved++;
+
+            $manager = $this->getManager($job);
+            $manager->remove($job);
+
+            if ($jobsRemoved % 50 === 0) {
+                $manager->flush();
+                $manager->clear();
+            }
+        }
+
+        if (null !== $manager) {
+            $manager->flush();
+        }
+
+        $io->success(sprintf('%d jobs removed', $jobsRemoved));
+
+        return 0;
+    }
+}

--- a/src/Command/TimeoutCommand.php
+++ b/src/Command/TimeoutCommand.php
@@ -21,7 +21,6 @@ final class TimeoutCommand extends Command
 
     protected static $defaultName = 'setono:job-status:timeout';
 
-    /** @var string|null */
     protected static $defaultDescription = "Clean up timed out jobs by moving them to the 'timed_out' state";
 
     private JobRepositoryInterface $jobRepository;

--- a/src/Repository/JobRepositoryInterface.php
+++ b/src/Repository/JobRepositoryInterface.php
@@ -35,7 +35,18 @@ interface JobRepositoryInterface extends ObjectRepository
      */
     public function findPassedTimeout(array $orderBy = null, int $limit = 1000, int $offset = null): array;
 
+    /**
+     * Returns the last job that was started by the given type
+     */
     public function findLastJobByType(string $type): ?JobInterface;
+
+    /**
+     * Returns a list of Jobs that wasn't updated since the given threshold
+     *
+     * @param array<string, string>|null $orderBy
+     * @psalm-return list<JobInterface>
+     */
+    public function findNotUpdatedSince(\DateTimeInterface $threshold, array $orderBy = null, int $limit = 1000, int $offset = null): array;
 
     /**
      * Returns true if an exclusive job of the given type is running

--- a/src/Resources/config/services/command.xml
+++ b/src/Resources/config/services/command.xml
@@ -2,9 +2,21 @@
 
 <container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <!-- The default is 30 days -->
+        <parameter key="setono_job_status.job.default_prune_threshold">720</parameter>
+    </parameters>
     <services>
         <service id="setono_job_status.command.jobs" class="Setono\JobStatusBundle\Command\ListCommand">
             <argument type="service" id="setono_job_status.repository.job"/>
+
+            <tag name="console.command"/>
+        </service>
+
+        <service id="setono_job_status.command.prune" class="Setono\JobStatusBundle\Command\PruneCommand">
+            <argument type="service" id="setono_job_status.repository.job"/>
+            <argument type="service" id="doctrine"/>
+            <argument>%setono_job_status.job.default_prune_threshold%</argument>
 
             <tag name="console.command"/>
         </service>

--- a/src/Resources/config/services/factory.xml
+++ b/src/Resources/config/services/factory.xml
@@ -4,11 +4,11 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <!-- The default ttl is 6 hours -->
-        <parameter key="setono_job_status.default_ttl">21600</parameter>
+        <parameter key="setono_job_status.job.default_ttl">21600</parameter>
     </parameters>
     <services>
         <service id="setono_job_status.factory.job" class="Setono\JobStatusBundle\Factory\JobFactory">
-            <argument>%setono_job_status.default_ttl%</argument>
+            <argument>%setono_job_status.job.default_ttl%</argument>
         </service>
     </services>
 </container>


### PR DESCRIPTION
This PR adds a command to remove/prune old jobs, i.e. jobs that aren't running and haven't been updated for a while (default is 30 days).

This is added to allow users to make sure the job status table isn't growing too big over time