### PR TITLE
Adding the doctrine spec instead of repository method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "doctrine/orm": "^2.7",
         "doctrine/persistence": "^1.3 || ^2.0",
         "eventsauce/backoff": "^1.1",
+        "happyr/doctrine-specification": "^2.0",
         "setono/doctrine-object-manager-trait": "^1.0",
         "stof/doctrine-extensions-bundle": "^1.6",
         "symfony/config": "^4.4 || ^5.0",

--- a/src/Entity/Spec/PassedTimeout.php
+++ b/src/Entity/Spec/PassedTimeout.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\JobStatusBundle\Entity\Spec;
+
+use Happyr\DoctrineSpecification\Spec;
+use Happyr\DoctrineSpecification\Specification\BaseSpecification;
+use Setono\JobStatusBundle\Entity\JobInterface;
+
+final class PassedTimeout extends BaseSpecification
+{
+    protected function getSpec()
+    {
+        return Spec::andX(
+            Spec::lt('timesOutAt', new \DateTime()),
+            Spec::eq('state', JobInterface::STATE_RUNNING)
+        );
+    }
+}

--- a/src/Repository/JobRepository.php
+++ b/src/Repository/JobRepository.php
@@ -6,6 +6,7 @@ namespace Setono\JobStatusBundle\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Repository\EntitySpecificationRepositoryTrait;
 use Setono\JobStatusBundle\Entity\JobInterface;
 use Webmozart\Assert\Assert;
 
@@ -14,6 +15,8 @@ use Webmozart\Assert\Assert;
  */
 class JobRepository extends ServiceEntityRepository implements JobRepositoryInterface
 {
+    use EntitySpecificationRepositoryTrait;
+
     public function findRunning(array $orderBy = ['updatedAt' => 'DESC'], int $limit = 1000, int $offset = null): array
     {
         return $this->findBy(['state' => JobInterface::STATE_RUNNING], $orderBy, $limit, $offset);
@@ -31,24 +34,6 @@ class JobRepository extends ServiceEntityRepository implements JobRepositoryInte
     public function findByType(string $type, array $orderBy = null, int $limit = 1000, int $offset = null): array
     {
         return $this->findBy(['type' => $type], $orderBy, $limit, $offset);
-    }
-
-    public function findPassedTimeout(array $orderBy = null, int $limit = 1000, int $offset = null): array
-    {
-        $qb = $this->createQueryBuilder('o')
-            ->andWhere('o.timesOutAt < :now')
-            ->andWhere('o.state = :state')
-            ->setParameter('now', new \DateTime())
-            ->setParameter('state', JobInterface::STATE_RUNNING)
-        ;
-
-        self::applyOrderBy($qb, $orderBy);
-        self::applyPagination($qb, $limit, $offset);
-
-        /** @psalm-var list<JobInterface> $res */
-        $res = $qb->getQuery()->getResult();
-
-        return $res;
     }
 
     public function findLastJobByType(string $type): ?JobInterface

--- a/src/Repository/JobRepositoryInterface.php
+++ b/src/Repository/JobRepositoryInterface.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Setono\JobStatusBundle\Repository;
 
 use Doctrine\Persistence\ObjectRepository;
+use Happyr\DoctrineSpecification\Repository\EntitySpecificationRepositoryInterface;
 use Setono\JobStatusBundle\Entity\JobInterface;
 
-interface JobRepositoryInterface extends ObjectRepository
+interface JobRepositoryInterface extends ObjectRepository, EntitySpecificationRepositoryInterface
 {
     /**
      * @param array<string, string> $orderBy
@@ -26,14 +27,6 @@ interface JobRepositoryInterface extends ObjectRepository
      * @psalm-return list<JobInterface>
      */
     public function findByType(string $type, array $orderBy = null, int $limit = 1000, int $offset = null): array;
-
-    /**
-     * Returns a list of Jobs where the timesOutAt timestamp has passed and are still running
-     *
-     * @param array<string, string>|null $orderBy
-     * @psalm-return list<JobInterface>
-     */
-    public function findPassedTimeout(array $orderBy = null, int $limit = 1000, int $offset = null): array;
 
     /**
      * Returns the last job that was started by the given type

--- a/tests/Command/TimeoutCommandTest.php
+++ b/tests/Command/TimeoutCommandTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\JobStatusBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\JobStatusBundle\Command\TimeoutCommand;
+use Setono\JobStatusBundle\Entity\Job;
+use Setono\JobStatusBundle\Entity\Spec\PassedTimeout;
+use Setono\JobStatusBundle\Manager\JobManagerInterface;
+use Setono\JobStatusBundle\Repository\JobRepositoryInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @covers \Setono\JobStatusBundle\Command\TimeoutCommand
+ */
+final class TimeoutCommandTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function it_executes(): void
+    {
+        $job = new Job();
+
+        $jobRepository = $this->prophesize(JobRepositoryInterface::class);
+        $jobRepository->iterate(new PassedTimeout())->willYield([$job]);
+        $jobManager = $this->prophesize(JobManagerInterface::class);
+
+        $commandTester = new CommandTester(new TimeoutCommand($jobRepository->reveal(), $jobManager->reveal()));
+        $commandTester->execute([]);
+
+        // the output of the command in the console
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString("1 job was transitioned to the 'timed_out' state", $output);
+    }
+}

--- a/tests/Entity/Spec/PassedTimeoutTest.php
+++ b/tests/Entity/Spec/PassedTimeoutTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\JobStatusBundle\Tests\Entity\Spec;
+
+use PHPUnit\Framework\TestCase;
+use Setono\JobStatusBundle\Entity\Job;
+use Setono\JobStatusBundle\Entity\JobInterface;
+use Setono\JobStatusBundle\Entity\Spec\PassedTimeout;
+
+/**
+ * @covers \Setono\JobStatusBundle\Entity\Spec\PassedTimeout
+ */
+final class PassedTimeoutTest extends TestCase
+{
+    /**
+     * @param bool $filtered true if the job satisfies the spec
+     * @dataProvider getJobs
+     * @test
+     */
+    public function it_filters(JobInterface $job, bool $filtered): void
+    {
+        $spec = new PassedTimeout();
+        self::assertSame($filtered, $spec->isSatisfiedBy($job));
+    }
+
+    /**
+     * @return iterable<array-key, array{0: JobInterface, 1: bool}>
+     */
+    public function getJobs(): iterable
+    {
+        $job = new Job();
+        $job->setTimesOutAt(new \DateTime('-10 minutes'));
+        $job->setState(JobInterface::STATE_RUNNING);
+
+        yield [$job, true];
+
+        $job = new Job();
+        $job->setTimesOutAt(new \DateTime('+10 minutes'));
+        $job->setState(JobInterface::STATE_RUNNING);
+
+        yield [$job, false];
+
+        $job = new Job();
+        $job->setTimesOutAt(new \DateTime('-10 minutes'));
+        $job->setState(JobInterface::STATE_PENDING);
+
+        yield [$job, false];
+    }
+}


### PR DESCRIPTION
This PR adds the [happyr/doctrine-specification](https://github.com/Happyr/Doctrine-Specification) library to make specification classes instead of having repository methods. It makes it way easier to test and provides very clean classes